### PR TITLE
Features/deploy task

### DIFF
--- a/buidler.config.js
+++ b/buidler.config.js
@@ -1,4 +1,6 @@
 require('dotenv').config()
+require('./tasks/balance')
+require('./tasks/deployNewSerie')
 
 usePlugin('@nomiclabs/buidler-waffle')
 usePlugin('@nomiclabs/buidler-web3')

--- a/deployments/kovan.json
+++ b/deployments/kovan.json
@@ -82,6 +82,23 @@
         "expirationDate": 19675741,
         "uniswapAddress": "0x78aBC109295157BD592148c6dCcDE696F5B041E5"
       }
+    },
+    {
+      "txId": "0xe897a835c5413244f95b7f713278aff6ebd7c9e9bab1d91869cf4cf5afd9bd35",
+      "timestamp": "2020-08-12T05:46:45.822Z",
+      "blockNumber": 20194920,
+      "deployer": "0x2367386801e28b15A7ef606fD55Fe455dfEE6053",
+      "option": "0x189172eEd289F3E8173Ed953F91E8D64Bc4E526e",
+      "optionExchangeAddress": "0x19e574836922BEb07cEcAf880eA0f075c52ECa8B",
+      "inputs": { 
+        "name": "Pods Put WBTC:USDC 7000 2020-08-27",
+        "symbol": "podWBTC:USDC",
+        "optionType": 0,
+        "underlyingAsset": "0x0094e8cf72acf138578e399768879cedd1ddd33c",
+        "strikeAsset": "0xe22da380ee6b445bb8273c81944adeb6e8450422",
+        "strikePrice": "7000000000",
+        "expirationDate": "20518519",
+        "uniswapFactory": "0x78aBC109295157BD592148c6dCcDE696F5B041E5" }
     }
   ]
 }

--- a/tasks/balance.js
+++ b/tasks/balance.js
@@ -1,0 +1,24 @@
+const BigNumber = require('bignumber.js')
+
+task('balance', "Prints an account's balance")
+  .addParam('account', "The account's address")
+  .addOptionalParam('erc20', 'Boolean if is ERC20')
+  .setAction(async ({ account, erc20 }, bre) => {
+    let balance
+    const _account = web3.utils.toChecksumAddress(account)
+    if (erc20) {
+      console.log('erc20', erc20)
+      const erc20Address = require(`../deployments/${bre.network.name}.json`)[erc20.toUpperCase()]
+      //   ethers.Contract
+
+      const ERC20Contract = await ethers.getContractAt('MockERC20', erc20Address)
+      balance = await ERC20Contract.balanceOf(_account)
+      const decimals = await ERC20Contract.decimals()
+      console.log('decimals', decimals)
+      console.log(balance.toString(), erc20)
+      console.log(balance.div(ethers.BigNumber.from(10).pow(decimals)).toString(), erc20.toUpperCase())
+    } else {
+      balance = await web3.eth.getBalance(_account)
+      console.log(web3.utils.fromWei(balance, 'ether'), 'ETH')
+    }
+  })

--- a/tasks/deployNewSerie.js
+++ b/tasks/deployNewSerie.js
@@ -1,0 +1,126 @@
+const BigNumber = require('bignumber.js')
+const UniswapFactoryABI = require('../abi/uniswap_factory.json')
+const UniswapExchangeABI = require('../abi/uniswap_exchange.json')
+const erc20ABI = require('../abi/erc20.json')
+const { getBlockDate } = require('../utils/utils')
+
+task('deploySerie', "Prints an account's balance")
+  .addParam('underlying', 'symbol of strike asset. (E.G: wbtc)')
+  .addParam('strike', 'symbol of strike asset. (E.G: usdc)')
+  .addParam('price', 'Units of strikeAsset in order to trade for 1 unit of underlying. (E.G: 7000)')
+  .addParam('expiration', 'Block number of the expiration')
+  .setAction(async ({ underlying, strike, price, expiration }, bre) => {
+    const strikeAsset = strike.toUpperCase()
+    const underlyingAsset = underlying.toUpperCase()
+
+    const strikeAssetAddress = require(`../deployments/${bre.network.name}.json`)[strikeAsset]
+    const underlyingAssetAddress = require(`../deployments/${bre.network.name}.json`)[underlyingAsset]
+    const { optionFactory, uniswapFactory } = require(`../deployments/${bre.network.name}.json`)
+    const [owner] = await ethers.getSigners()
+    const deployerAddress = await owner.getAddress()
+    let optionAddress
+    let txIdNewOption
+
+    // TODO: function to build option name and symbol based on underyingAsset,strikeAsset,strikePrice and Date
+    const currentBlockNumber = await ethers.provider.getBlockNumber()
+    const expirationInDate = getBlockDate(currentBlockNumber, expiration, bre.network.config.network_id)
+    const strikeAssetContract = new ethers.Contract(strikeAssetAddress, erc20ABI, owner)
+
+    const strikeDecimals = await strikeAssetContract.decimals()
+
+    const strikePrice = new BigNumber(price).multipliedBy(10 ** strikeDecimals).toString()
+    const optionParams = {
+      name: `Pods Put ${underlyingAsset}:${strikeAsset} ${price} ${expirationInDate.toISOString().slice(0, 10)}`, // Pods Put WBTC:USDC 7000 2020-07-10
+      symbol: `pod${underlyingAsset}:${strikeAsset}`, // Pods Put WBTC:USDC 7000 2020-07-10
+      optionType: 0, // 0 for put, 1 for call
+      underlyingAsset: underlyingAssetAddress, // 0x0094e8cf72acf138578e399768879cedd1ddd33c
+      strikeAsset: strikeAssetAddress, // 0xe22da380ee6B445bb8273C81944ADEB6E8450422
+      strikePrice: strikePrice, // 7000e6 if strike is USDC,
+      expirationDate: expiration, // 19443856 = 10 july
+      uniswapFactory
+    }
+
+    console.log('Optiion Parameters')
+    console.log(optionParams)
+
+    // TODO: check price api, instead of hardcoded
+    const currentEtherPriceInUSD = 225 // Checked on uniswap v1 usdc/eth pool
+    const optionPremiumInUSD = 6
+    const amountOfOptionsToMint = 10
+
+    const optionPremiumInETH = optionPremiumInUSD / currentEtherPriceInUSD // currentEtherPriceInUSD / optionPremium
+    const amountOfEthToAddLiquidity = new BigNumber(1e18).multipliedBy(optionPremiumInETH).multipliedBy(amountOfOptionsToMint).toString() // optionPremiumInETH * Amount
+    // Amount * (10 ** optionDecimals)
+
+    const funcParameters = [
+      optionParams.name,
+      optionParams.symbol,
+      optionParams.optionType,
+      optionParams.underlyingAsset,
+      optionParams.strikeAsset,
+      optionParams.strikePrice,
+      optionParams.expirationDate,
+      optionParams.uniswapFactory
+    ]
+
+    // 1) Create Option
+    const FactoryContract = await ethers.getContractAt('OptionFactory', optionFactory)
+    const UnderlyingContract = new ethers.Contract(optionParams.underlyingAsset, erc20ABI, owner)
+    const underlyingAssetSymbol = await UnderlyingContract.symbol()
+    // const underlyingAssetSymbol = 'WETH'
+
+    console.log('Underlying Asset Symbol: ' + underlyingAssetSymbol)
+    if (underlyingAssetSymbol === 'WETH') {
+      txIdNewOption = await FactoryContract.createEthOption(...funcParameters)
+    } else {
+      txIdNewOption = await FactoryContract.createOption(...funcParameters)
+    }
+    const filterFrom = await FactoryContract.filters.OptionCreated(deployerAddress)
+    const eventDetails = await FactoryContract.queryFilter(filterFrom, txIdNewOption.blockNumber, txIdNewOption.blockNumber)
+    console.log('txId: ', txIdNewOption.hash)
+    console.log('timestamp: ', new Date())
+    await txIdNewOption.wait()
+    if (eventDetails.length) {
+      const { deployer, option } = eventDetails[0].args
+      console.log('blockNumber: ', eventDetails[0].blockNumber)
+      console.log('deployer: ', deployer)
+      console.log('option: ', option)
+      optionAddress = option
+    } else {
+      console.log('Something went wrong: No events found')
+    }
+    // 2) Create new Uniswap Exchange with OptionAddress
+    console.log('Create New Uniswap Exchange')
+    const UniswapFactoryContract = new web3.eth.Contract(UniswapFactoryABI, uniswapFactory)
+    const txCreateExchange = await UniswapFactoryContract.methods.createExchange(optionAddress).send({ from: deployerAddress })
+    setTimeout(() => 0, 5000)
+    const optionExchangeAddress = await UniswapFactoryContract.methods.getExchange(optionAddress).call()
+    console.log('optionExchangeAddress: ', optionExchangeAddress)
+
+    // 3) Mint first Options
+    const OptionContract = await ethers.getContractAt('PodPut', optionAddress)
+    const ExchangeContract = new web3.eth.Contract(UniswapExchangeABI, optionExchangeAddress)
+
+    // 3a) Approve StrikeAsset between me and option Contract
+
+    console.log('Strike Asset', await strikeAssetContract.symbol())
+    await strikeAssetContract.approve(optionAddress, (ethers.constants.MaxUint256).toString())
+
+    // 3b) Call option Mint
+    const optionDecimals = await OptionContract.decimals()
+    console.log('optionDecimals: ', optionDecimals)
+    const amountOfOptionsToAddLiquidity = new BigNumber(amountOfOptionsToMint).multipliedBy(10 ** optionDecimals).toString()
+    const txIdMint = await OptionContract.mint(amountOfOptionsToAddLiquidity)
+    await txIdMint.wait()
+    console.log('Option Balance after mint', (await OptionContract.balanceOf(deployerAddress)).toString())
+
+    // 4) Add Liquidity to Uniswap Exchange
+    // 4a) Approve Option contract to exchange spender
+    const txIdApprove = await OptionContract.approve(optionExchangeAddress, (ethers.constants.MaxUint256).toString())
+    await txIdApprove.wait()
+    // // 4b) Add liquidity per se
+
+    await ExchangeContract.methods.addLiquidity(0, amountOfOptionsToAddLiquidity, (ethers.constants.MaxUint256).toString()).send({ from: deployerAddress, value: amountOfEthToAddLiquidity })
+    console.log('Liquidity Added')
+    console.log('Option Balance after liquidity added', (await OptionContract.balanceOf(deployerAddress)).toString())
+  })

--- a/tasks/deployNewSerie.js
+++ b/tasks/deployNewSerie.js
@@ -4,7 +4,7 @@ const UniswapExchangeABI = require('../abi/uniswap_exchange.json')
 const erc20ABI = require('../abi/erc20.json')
 const { getBlockDate } = require('../utils/utils')
 
-task('deploySerie', "Prints an account's balance")
+task('deploySerie', 'Initial Option series setup: create an option, create a uniswap exchange and add initial liquidity')
   .addParam('underlying', 'symbol of strike asset. (E.G: wbtc)')
   .addParam('strike', 'symbol of strike asset. (E.G: usdc)')
   .addParam('price', 'Units of strikeAsset in order to trade for 1 unit of underlying. (E.G: 7000)')

--- a/tasks/deployNewSerie.js
+++ b/tasks/deployNewSerie.js
@@ -5,7 +5,7 @@ const erc20ABI = require('../abi/erc20.json')
 const { getBlockDate } = require('../utils/utils')
 
 task('deploySerie', 'Initial Option series setup: create an option, create a uniswap exchange and add initial liquidity')
-  .addParam('underlying', 'symbol of strike asset. (E.G: wbtc)')
+  .addParam('underlying', 'symbol of underlying asset. (E.G: wbtc)')
   .addParam('strike', 'symbol of strike asset. (E.G: usdc)')
   .addParam('price', 'Units of strikeAsset in order to trade for 1 unit of underlying. (E.G: 7000)')
   .addParam('expiration', 'Block number of the expiration')

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -16,4 +16,49 @@ function getMonthLetter (month) {
   }
 }
 
-module.exports = getMonthLetter
+const avgBlocktime = {
+  1: 15,
+  42: 4
+}
+
+/**
+ * Returns the date of block in the Ethereum network
+ * @param {number} currentBlockNumber
+ * @param {number} targetBlockNumber
+ * @returns {Date}
+ */
+function getBlockDate (currentBlockNumber, targetBlockNumber, networkVersion) {
+  console.log('currentBlockNumber')
+  console.log(currentBlockNumber)
+  console.log('targetBlockNumber')
+  console.log(targetBlockNumber)
+  console.log('networkVersion')
+  console.log(networkVersion)
+  const diffBetweenBlocksInMilliseconds = (targetBlockNumber - currentBlockNumber) * avgBlocktime[networkVersion] * 1000
+  const now = new Date().valueOf()
+  const targetDate = new Date(now + diffBetweenBlocksInMilliseconds)
+
+  return targetDate
+}
+
+/**
+ * Returns the future block number given a date
+ * @param {number} currentBlockNumber
+ * @param {Date} targetDate in utc (milliseconds)
+ * @returns {number} futureBlockNumber
+ */
+function getFutureBlockNumber (currentBlockNumber, targetDate, networkVersion) {
+  const now = new Date().valueOf()
+  const diffBetweenDatesInMilliseconds = targetDate - now
+  const blocksPassed = diffBetweenDatesInMilliseconds / (avgBlocktime[networkVersion] * 1000)
+
+  const futureBlockNumber = currentBlockNumber + blocksPassed
+
+  return futureBlockNumber
+}
+
+module.exports = {
+  getMonthLetter,
+  getBlockDate,
+  getFutureBlockNumber
+}

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -28,12 +28,6 @@ const avgBlocktime = {
  * @returns {Date}
  */
 function getBlockDate (currentBlockNumber, targetBlockNumber, networkVersion) {
-  console.log('currentBlockNumber')
-  console.log(currentBlockNumber)
-  console.log('targetBlockNumber')
-  console.log(targetBlockNumber)
-  console.log('networkVersion')
-  console.log(networkVersion)
   const diffBetweenBlocksInMilliseconds = (targetBlockNumber - currentBlockNumber) * avgBlocktime[networkVersion] * 1000
   const now = new Date().valueOf()
   const targetDate = new Date(now + diffBetweenBlocksInMilliseconds)


### PR DESCRIPTION
Now you can deploy a new options series directly as a buidler task. Example:

`npx buidler deploySerie --network kovan --underlying wbtc --strike usdc --price 7000 --expiration 20518519`

![Screen Shot 2020-08-12 at 03 04 53](https://user-images.githubusercontent.com/11945073/89980619-a27bcd80-dc48-11ea-9e39-3d1dd1ef8470.png)


Future work:

- [ ] Split `create uniswap exchange` and `initial liquidity` into internal tasks
- [ ] Create parameters for `initial liquidity`
- [ ] Create a smarter CLI menu (or front end) for deploying options
